### PR TITLE
Make use of mocha's new native promise support

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "moment": "~2.5.1"
   },
   "devDependencies": {
-    "mocha-as-promised": "~2.0.0",
-    "mocha": "~1.17.1",
+    "mocha": "~1.18",
     "jshint": "~2.4.4",
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-watch": "~0.6.0",

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,2 +1,1 @@
 global.go = {};
-require('mocha-as-promised')();


### PR DESCRIPTION
Mocha 1.18 supports promises natively.
