### PR TITLE
Add warning header to generated go-app.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,6 +52,14 @@ module.exports = function (grunt) {
         },
 
         concat: {
+            options: {
+                banner: [
+                    '// WARNING: This is a generated file.',
+                    '//          If you edit it you will be sad.',
+                    '//          Edit src/app.js instead.',
+                    '\n' // Newline between banner and content.
+                ].join('\n')
+            },
             prd: {
                 src: ['<%= paths.src.prd %>'],
                 dest: '<%= paths.dest.prd %>'

--- a/go-app.js
+++ b/go-app.js
@@ -1,3 +1,7 @@
+// WARNING: This is a generated file.
+//          If you edit it you will be sad.
+//          Edit src/app.js instead.
+
 var go = {};
 go;
 


### PR DESCRIPTION
So that people don't edit it and then wonder why all their changes keep disappearing.
